### PR TITLE
Add fd as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ With this plugin you can connect to a replay session and debug it as any other D
 Requirements:
 - A reasonably modern neovim (tested on v0.9.2, but older versions should work as well)
 - [rr](https://github.com/rr-debugger/rr) (tested on 5.6.0)
+- [fd](https://github.com/sharkdp/fd)
 - [cpptools](https://github.com/Microsoft/vscode-cpptools)
     - [mason.nvim](https://github.com/williamboman/mason.nvim) makes the installation trivial (see [minimal configuration](#minimal-configuration))
 


### PR DESCRIPTION
Hi. I just read your blogpost about rr, DAP and neovim and I really liked it! I don't understand why rr gets so little attention. Internet says that gdb got support for reverse debugging on x86_64 since version 7.0 but that simply doesn't work.

I was trying out the config myself, but a pretty cryptic error message has occurred. I have tracked it down to this: https://github.com/jonboh/nvim-dap-rr/blob/main/lua/nvim-dap-rr.lua#L21

My commit documents `fd` as a dependency. A better solution would probably be to use the more portable `find` utility. But I have zero experience with making neovim plugins, so I did this instead.